### PR TITLE
Include wget as a dependency for post-link script

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - pybind11                               # [build_platform != target_platform]
     - make    # [unix]
     - boost-cpp {{ boost_cpp }}
-    - wget
+    - curl
 
   host:
     # Packages that need to be specific to the target platform when the
@@ -59,7 +59,7 @@ requirements:
     - python
     - eigen
     - pybind11
-    - wget
+    - curl
 
   run:
     # Packages required to run the package. These are the dependencies
@@ -73,7 +73,7 @@ requirements:
     - {{ pin_compatible('matplotlib') }}
     - {{ pin_compatible('basemap') }}
     - python
-    - wget
+    - curl
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ requirements:
     - pybind11                               # [build_platform != target_platform]
     - make    # [unix]
     - boost-cpp {{ boost_cpp }}
+    - wget
 
   host:
     # Packages that need to be specific to the target platform when the
@@ -58,6 +59,7 @@ requirements:
     - python
     - eigen
     - pybind11
+    - wget
 
   run:
     # Packages required to run the package. These are the dependencies
@@ -71,6 +73,7 @@ requirements:
     - {{ pin_compatible('matplotlib') }}
     - {{ pin_compatible('basemap') }}
     - python
+    - wget
 
 test:
   imports:

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -28,6 +28,6 @@ mkdir -p $TARGET_LOCATION
 cd $TARGET_LOCATION
 
 # Fetch the Github release containing the raw data files
-wget $RESOURCE_GITHUB_URL
+curl -JLO $RESOURCE_GITHUB_URL
 
 


### PR DESCRIPTION
Include `wget` as a dependency for post-link script as pointed out by the error trace of the previous build triggered as a reuslt of changes introduced in #10 :
```
stdout: 

stderr: /home/conda/feedstock_root/build_artifacts/tudatpy_1657896921360/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/bin/.tudatpy-post-link.sh: line 31: wget: command not found
```

