### PR TITLE
Move installation to build script

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,8 +25,7 @@ make
 make install
 
 # Go back to source root to install pytrk234
-cd ..
 echo "Installing pytrk234..."
-$PYTHON -m pip install ./pytrk234 --no-deps --ignore-installed -vv
+$PYTHON -m pip install git+https://github.com/NASA-PDS/PyTrk234.git --no-deps -vv
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,8 +85,6 @@ requirements:
     - colorama
     - tqdm
     - boost-cpp {{ boost_cpp }}
-    - pip:
-      - git+https://github.com/NASA-PDS/PyTrk234.git
 
 
 test:


### PR DESCRIPTION
Move installation to the build script as recommended by best practises. Like this it will be available for tests and for the final user